### PR TITLE
updated white space

### DIFF
--- a/lichess_bot/models/lichess_bot/components/Engine/Engine.xtuml
+++ b/lichess_bot/models/lichess_bot/components/Engine/Engine.xtuml
@@ -3,13 +3,13 @@
 within lichess_bot::components is
 
   component Engine is
-
+    
     package EEs is lichess_bot::EEs;
     package bot;
     package functions;
     package games;
     package types is lichess_bot::types;
-
+    
     required port chess implements LichessAPI is
 
       @dialect("oal");
@@ -50,15 +50,15 @@ within lichess_bot::components is
         @noparse
         LOG::LogInfo(message:"Received challenge: " + param.challenge.id);
         c = param.challenge;
-
+        
         select any bot from instances of Bot;
-
+        
         // handle incoming challenges
         if c.challenger.id != bot.user.id then
-
+        
           accept_challenge = true;
           reason = DeclineReason::GENERIC;
-
+        
           // only accept the challenge if not at the max number of active games
           // default to one game at a time
           max_games = Bot::getInteger(name: "max_games", default_value: 1);
@@ -67,33 +67,33 @@ within lichess_bot::components is
             accept_challenge = false;
             reason = DeclineReason::LATER;
           end if;
-
+        
           // only accept unrated standard games
           if c.rated then
             accept_challenge = false;
             reason = DeclineReason::CASUAL;
           end if;
-
+        
           // only accept standard games or from position games
           if not (c.variant == Variant::STANDARD or c.variant == Variant::FROMPOSITION) then
             accept_challenge = false;
             reason = DeclineReason::STANDARD;
           end if;
-
+        
           // send the accept or decline message
           if accept_challenge then
             result = chess::acceptChallenge(challenge_id:c.id);
           else
             result = chess::declineChallenge(challenge_id:c.id, reason:reason);
           end if;
-
+        
         else
-
+        
           LOG::LogInfo(message: "Watch outgoing challenge at: " + c.url );
           if Bot::getBoolean(name: "auto_open_challenge_url", default_value: false) then
             ARCH::openURL(url:c.url);
           end if;
-
+        
         end if;
         @endnoparse
       end message;
@@ -109,22 +109,22 @@ within lichess_bot::components is
       message chatLine(game_id: in string, username: in string, text: in string, room: in Room) from provider is
         @noparse
         LOG::LogInfo(message:"Chat line: " + param.game_id + ", " + param.username + ": " + param.text);
-
+        
         select any game from instances of ActiveGame where selected.id == param.game_id;
         if not empty game then
-
+        
           // handle takeback proposals
           if param.username == "lichess" and param.room == Room::PLAYER and param.text == "Takeback sent" then
             game.handle_takeback_proposal();
           end if;
-
+        
           // handle draw offers
           if param.username == "lichess" and param.room == Room::PLAYER and
             ((game.color == Color::WHITE and param.text == "Black offers draw") or
             (game.color == Color::BLACK and param.text == "White offers draw")) then
             game.handle_draw_offer();
           end if;
-
+        
         end if;
         @endnoparse
       end message;
@@ -160,13 +160,13 @@ within lichess_bot::components is
         @noparse
         LOG::LogInfo(message:"Game full: " + param.game.id);
         g = param.game;
-
+        
         // find/create the game
         select any game from instances of ActiveGame where selected.id == g.id;
         if empty game then
           game = ActiveGame::new_game(id: g.id);
         end if;
-
+        
         // set color for the game
         select any bot from instances of Bot;
         if g.white.name == bot.user.username then
@@ -174,7 +174,7 @@ within lichess_bot::components is
         else
           game.color = Color::BLACK;
         end if;
-
+        
         // set the initial FEN
         if g.initialFen == "startpos" then
           game.initial_fen = ChessLib::startpos();
@@ -187,7 +187,7 @@ within lichess_bot::components is
             game.start_color = Color::BLACK;
           end if;
         end if;
-
+        
         // update the game state
         game.update_game_state(game_state: g.gameState);
         @endnoparse
@@ -200,7 +200,7 @@ within lichess_bot::components is
         r = chess::chat(game_id:param.game_event.id, text: "version: " + Bot::getString(name: "version", default_value: "unknown"), room:Room::PLAYER);
         r = chess::chat(game_id:param.game_event.id, text:"Good luck!", room:Room::PLAYER);
         g = param.game_event;
-
+        
         // find/create a game
         select any game from instances of ActiveGame where selected.id == g.id;
         if empty game then
@@ -224,19 +224,19 @@ within lichess_bot::components is
       message opponentGone(game_id: in string, gone: in boolean, claim_win_in_seconds: in integer) from provider is
         @noparse
         LOG::LogInfo(message:"Opponent gone: " + param.game_id);
-
+        
         select any game from instances of ActiveGame where selected.id == param.game_id;
         if not empty game then
-
+        
           // cancel the timer if it exists
           r = TIM::timer_cancel(timer_inst_ref: game.claim_victory_timer);
-
+        
           // if the opponent is gone, claim victory after the specified delay
           if param.gone then
             create event instance e of ActiveGame5:'claim victory' to game;
             game.claim_victory_timer = TIM::timer_start(event_inst: e, microseconds: param.claim_win_in_seconds * 1000000);
           end if;
-
+        
         end if;
         @endnoparse
       end message;

--- a/lichess_bot/models/lichess_bot/components/Engine/functions/functions.xtuml
+++ b/lichess_bot/models/lichess_bot/components/Engine/functions/functions.xtuml
@@ -13,10 +13,10 @@ within lichess_bot::components::Engine is
         create object instance bot of Bot;
         bot.config = PROP::loadProperties(file_name:"lichess_bot.properties");
       end if;
-
+      
       // connect to the Lichess API and start listening for events
       send chess::connect(properties: bot.config);
-
+      
       LOG::LogInfo(message: "Initialization complete");
       @endnoparse
     end function;

--- a/lichess_bot/models/lichess_bot/components/Engine/games/Active Game/Active Game.xtuml
+++ b/lichess_bot/models/lichess_bot/components/Engine/games/Active Game/Active Game.xtuml
@@ -63,7 +63,7 @@ within lichess_bot::components::Engine::games is
     operation update_game_state(game_state: in GameState) is
       @noparse
       self.game_state = param.game_state;
-
+      
       // check if the game is over
       if not (self.game_state.status == GameStatus::CREATED or self.game_state.status == GameStatus::STARTED) then
           generate ActiveGame2:'game over'(status: self.game_state.status) to self;
@@ -84,7 +84,7 @@ within lichess_bot::components::Engine::games is
       // create the game
       create object instance game of ActiveGame;
       game.id = param.id;
-
+      
       return game;
       @endnoparse
     end operation;

--- a/lichess_bot/models/lichess_bot/components/Engine/games/Active Game/InstanceStateMachine/InstanceStateMachine.xtuml
+++ b/lichess_bot/models/lichess_bot/components/Engine/games/Active Game/InstanceStateMachine/InstanceStateMachine.xtuml
@@ -69,19 +69,19 @@ within lichess_bot::components::Engine::games::'Active Game' is
       (self.color == Color::BLACK and self.game_state.wtakeback) then
       self.handle_takeback_proposal();
     end if;
-
+    
     // handle draw offers
     if (self.color == Color::WHITE and self.game_state.bdraw) or
       (self.color == Color::BLACK and self.game_state.wdraw) then
       self.handle_draw_offer();
     end if;
-
+    
     // select a random legal move
     legal_moves = ChessLib::legalMoves(fen: ChessLib::movesToFEN(initialFen: self.initial_fen, moves: self.game_state.moves));
     i = 0;  // coerce integer
     i = TIM::current_clock() % legal_moves.length;
     move = legal_moves[i];
-
+    
     // play the move
     create event instance e of ActiveGame3:'play move'(move: move) to self;
     t = TIM::timer_start(event_inst:e, microseconds: 0);
@@ -91,7 +91,7 @@ within lichess_bot::components::Engine::games::'Active Game' is
   state 'playing move'(move: in string) is
     @noparse
     move = param.move;
-
+    
     // play the move
     success = chess::move(game_id: self.id, move: move);
     if success then

--- a/lichess_bot/models/lichess_bot/lichess_bot.xtuml
+++ b/lichess_bot/models/lichess_bot/lichess_bot.xtuml
@@ -2,11 +2,11 @@
 
 @system_model(use_globals=true);
 package lichess_bot is
-
+  
   package EEs;
   package components;
   package system;
   package types;
-
+  
 end package;
 

--- a/lichess_bot/models/lichess_bot/types/lichess/lichess.xtuml
+++ b/lichess_bot/models/lichess_bot/types/lichess/lichess.xtuml
@@ -38,15 +38,15 @@ within lichess_bot::types is
     end structure;
 
     type ChallengeDirection is enum (
-      IN,
+      IN, 
       OUT
     );
 
     type ChallengeStatus is enum (
-      CREATED,
-      OFFLINE,
-      CANCELED,
-      DECLINED,
+      CREATED, 
+      OFFLINE, 
+      CANCELED, 
+      DECLINED, 
       ACCEPTED
     );
 
@@ -57,22 +57,22 @@ within lichess_bot::types is
     end structure;
 
     type Color is enum (
-      WHITE,
-      BLACK,
+      WHITE, 
+      BLACK, 
       RANDOM
     );
 
     type DeclineReason is enum (
-      GENERIC,
-      LATER,
-      TOOFAST,
-      TOOSLOW,
-      TIMECONTROL,
-      RATED,
-      CASUAL,
-      STANDARD,
-      VARIANT,
-      NOBOT,
+      GENERIC, 
+      LATER, 
+      TOOFAST, 
+      TOOSLOW, 
+      TIMECONTROL, 
+      RATED, 
+      CASUAL, 
+      STANDARD, 
+      VARIANT, 
+      NOBOT, 
       ONLYBOT
     );
 
@@ -98,26 +98,26 @@ within lichess_bot::types is
     end structure;
 
     type GameSource is enum (
-      LOBBY,
-      FRIEND,
-      AI,
-      API,
-      TOURNAMENT,
-      POSITION,
-      IMPORT,
-      IMPORTLIVE,
-      SIMUL,
-      RELAY,
-      POOL,
+      LOBBY, 
+      FRIEND, 
+      AI, 
+      API, 
+      TOURNAMENT, 
+      POSITION, 
+      IMPORT, 
+      IMPORTLIVE, 
+      SIMUL, 
+      RELAY, 
+      POOL, 
       SWISS
     );
 
     type GameSpeed is enum (
-      ULTRABULLET,
-      BULLET,
-      BLITZ,
-      RAPID,
-      CLASSICAL,
+      ULTRABULLET, 
+      BULLET, 
+      BLITZ, 
+      RAPID, 
+      CLASSICAL, 
       CORRESPONDENCE
     );
 
@@ -136,18 +136,18 @@ within lichess_bot::types is
     end structure;
 
     type GameStatus is enum (
-      CREATED,
-      STARTED,
-      ABORTED,
-      MATE,
-      RESIGN,
-      STALEMATE,
-      TIMEOUT,
-      DRAW,
-      OUTOFTIME,
-      CHEAT,
-      NOSTART,
-      UNKNOWNFINISH,
+      CREATED, 
+      STARTED, 
+      ABORTED, 
+      MATE, 
+      RESIGN, 
+      STALEMATE, 
+      TIMEOUT, 
+      DRAW, 
+      OUTOFTIME, 
+      CHEAT, 
+      NOSTART, 
+      UNKNOWNFINISH, 
       VARIANTEND
     );
 
@@ -162,7 +162,7 @@ within lichess_bot::types is
     end structure;
 
     type Room is enum (
-      PLAYER,
+      PLAYER, 
       SPECTATOR
     );
 
@@ -181,30 +181,30 @@ within lichess_bot::types is
     end structure;
 
     type UserTitle is enum (
-      GM,
-      WGM,
-      IM,
-      WIM,
-      FM,
-      WFM,
-      NM,
-      CM,
-      WCM,
-      WNM,
-      LM,
+      GM, 
+      WGM, 
+      IM, 
+      WIM, 
+      FM, 
+      WFM, 
+      NM, 
+      CM, 
+      WCM, 
+      WNM, 
+      LM, 
       BOT
     );
 
     type Variant is enum (
-      STANDARD,
-      CHESS960,
-      CRAZYHOUSE,
-      ANTICHESS,
-      ATOMIC,
-      HORDE,
-      KINGOFTHEHILL,
-      RACINGKINGS,
-      THREECHECK,
+      STANDARD, 
+      CHESS960, 
+      CRAZYHOUSE, 
+      ANTICHESS, 
+      ATOMIC, 
+      HORDE, 
+      KINGOFTHEHILL, 
+      RACINGKINGS, 
+      THREECHECK, 
       FROMPOSITION
     );
 

--- a/lichess_bot/models/lichess_bot/types/types.xtumlg
+++ b/lichess_bot/models/lichess_bot/types/types.xtumlg
@@ -5,7 +5,7 @@ shapes :
     render : user_data_type "lichess_bot::types::Properties"
     bounds : x : 4180.0 y : 0.0 width : 200.0 height : 150.0
   shape : lichess
-    render : package "lichess_bot::types::lichess"
+    render : package "lichess"
     bounds : x : 4400.0 y : 0.0 width : 200.0 height : 150.0
 
 connectors :


### PR DESCRIPTION
Persistence adds some superfluous and harmless white space in some places (e.g. after enumerators, before after the body of a package, ...). This had been removed but is being put back to minimize changes sets.